### PR TITLE
Add a link to the service logo

### DIFF
--- a/frontend/src/Articles.test.tsx
+++ b/frontend/src/Articles.test.tsx
@@ -37,8 +37,8 @@ describe("Articles", () => {
     })) as HTMLAnchorElement;
 
     expect(articleLink).toBeInTheDocument();
-    expect(articleLink.href).toMatch(
-      /\/articles\/d8fec293-97c1-46b7-a1d4-458da3689dcd$/,
+    expect(articleLink.href).toBe(
+      window.location.origin + "/articles/d8fec293-97c1-46b7-a1d4-458da3689dcd",
     );
   });
 });

--- a/frontend/src/Header.test.tsx
+++ b/frontend/src/Header.test.tsx
@@ -12,14 +12,27 @@ describe("Header", () => {
     }) as HTMLAnchorElement;
 
     expect(loginLink).toBeInTheDocument();
-    expect(loginLink.href).toMatch(/\/login$/);
+    expect(loginLink.href).toBe(window.location.origin + "/login");
   });
 
-  it("shows a service logo", () => {
-    render(<Header />, { wrapper: MemoryRouter });
+  describe("Service Logo", () => {
+    it("is in the header", () => {
+      render(<Header />, { wrapper: MemoryRouter });
 
-    const logo = screen.getByRole("img", { name: "Site Logo" });
+      const logo = screen.getByRole("img", { name: "Site Logo" });
 
-    expect(logo).toBeInTheDocument();
+      expect(logo).toBeInTheDocument();
+    });
+
+    it("is linked to '/'", () => {
+      render(<Header />, { wrapper: MemoryRouter });
+
+      const logoLink = screen.getByRole("link", {
+        name: "Site Logo",
+      }) as HTMLAnchorElement;
+
+      expect(logoLink).toBeInTheDocument();
+      expect(logoLink.href).toBe(window.location.origin + "/");
+    });
   });
 });

--- a/frontend/src/Header.tsx
+++ b/frontend/src/Header.tsx
@@ -6,11 +6,13 @@ export default function Header() {
     <header className={styles.headerContainer}>
       <nav className={styles.navContainer}>
         <div className={styles.headerLogo}>
-          <img
-            className={styles.headerLogoImage}
-            src="/ktlog.webp"
-            alt="Site Logo"
-          />
+          <Link to="/">
+            <img
+              className={styles.headerLogoImage}
+              src="/ktlog.webp"
+              alt="Site Logo"
+            />
+          </Link>
         </div>
         <div className={styles.headerLinkContainer}>
           <Link to="/login">Login</Link>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Test: Modified test case for `Articles` component to update the expected value of the `href` attribute, ensuring it is an absolute URL.
- Test: Added two new tests for the service logo in the `Header` component, verifying its rendering and link to the root URL.
- New Feature: Added a clickable link to the service logo in the header, enhancing user experience by providing easy navigation back to the homepage.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->