### PR TITLE
✨ Add "dev|" to the browser title for local development

### DIFF
--- a/backend/src/test/kotlin/org/mahata/ktlog/ArticlesControllerTest.kt
+++ b/backend/src/test/kotlin/org/mahata/ktlog/ArticlesControllerTest.kt
@@ -87,7 +87,7 @@ class ArticlesControllerTest {
             val mockArticle = ArticlesRequest("my title", "my content")
 
             every {
-                stubArticlesService.saveArticle(ArticlesRequest(mockArticle.title, mockArticle.content))
+                stubArticlesService.saveArticle(mockArticle)
             } returns Unit
 
             val objectMapper = ObjectMapper()

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,53 @@
+import App from "./App";
+import { act, render, waitFor } from "@testing-library/react";
+import { StubArticlesRepository } from "./StubRepos";
+import { MemoryRouter } from "react-router-dom";
+
+const originalTitle = document.title;
+
+describe("App", () => {
+  it.each(["localhost", "127.0.0.1"])(
+    'adds "dev|" to the title when it runs on the localhost',
+    async (serviceDomain) => {
+      const stubArticleRepository = new StubArticlesRepository();
+      stubArticleRepository.getAll.mockResolvedValue([]);
+
+      render(
+        <App
+          ktlogDomain={serviceDomain}
+          articlesRepository={stubArticleRepository}
+        />,
+        {
+          wrapper: MemoryRouter,
+        },
+      );
+
+      await waitFor(() => {
+        expect(document.title).toBe(`dev|${originalTitle}`);
+      });
+    },
+  );
+
+  it('do NOT add "dev|" when it is not running on the localhost', async () => {
+    const stubArticleRepository = new StubArticlesRepository();
+    stubArticleRepository.getAll.mockResolvedValue([]);
+
+    await act(async () => {
+      render(
+        <App
+          ktlogDomain="example.com"
+          articlesRepository={stubArticleRepository}
+        />,
+        {
+          wrapper: MemoryRouter,
+        },
+      );
+    });
+
+    expect(document.title).toBe(originalTitle);
+  });
+
+  afterEach(() => {
+    document.title = originalTitle;
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,12 +5,20 @@ import Header from "./Header";
 import EyeCatch from "./EyeCatch";
 import { Route, Routes } from "react-router-dom";
 import Article from "./Article";
+import { useEffect } from "react";
 
 type Props = {
+  ktlogDomain: string;
   articlesRepository: ArticlesRepository;
 };
 
-export default function App({ articlesRepository }: Props) {
+export default function App({ ktlogDomain, articlesRepository }: Props) {
+  useEffect(() => {
+    if (["localhost", "127.0.0.1"].includes(ktlogDomain)) {
+      document.title = `dev|${document.title}`;
+    }
+  }, [ktlogDomain]);
+
   return (
     <div>
       <Header />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,7 +10,10 @@ const networkArticlesRepo = new NetworkArticlesRepository();
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App articlesRepository={networkArticlesRepo} />
+      <App
+        ktlogDomain={window.location.hostname}
+        articlesRepository={networkArticlesRepo}
+      />
     </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Simplified argument in `stubArticlesService.saveArticle()` method in `ArticlesControllerTest` for improved code readability and reduced redundancy.
- Test: Added tests for the `App` component to check the document title prefix when rendered on localhost and other domains.
- New Feature: Modified `App` component to introduce a new prop `ktlogDomain` that modifies the browser title with a "dev|" prefix when the domain is "localhost" or "127.0.0.1".
- Chore: Modified `main.tsx` to pass the `ktlogDomain` prop to the `App` component, suggesting a change in the external interface and potential impact on behavior.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->