### PR TITLE
✨ Add an endpoint to return authenticated user info

### DIFF
--- a/backend/src/main/kotlin/org/mahata/ktlog/UsersController.kt
+++ b/backend/src/main/kotlin/org/mahata/ktlog/UsersController.kt
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 data class UserResponse(
-    val name: String,
-    val email: String
+    val name: String? = null,
+    val email: String? = null
 )
 
 @RestController
@@ -16,10 +16,10 @@ data class UserResponse(
 class UsersController {
 
     @GetMapping("/me")
-    fun me(@AuthenticationPrincipal user: OAuth2User): UserResponse {
+    fun me(@AuthenticationPrincipal user: OAuth2User?): UserResponse {
         return UserResponse(
-            name = user.attributes.getOrDefault("name", "NO_NAME") as String,
-            email = user.attributes.getOrDefault("email", "NO_EMAIL") as String
+            name = user?.attributes?.get("name") as? String,
+            email = user?.attributes?.get("email") as? String
         )
     }
 }

--- a/backend/src/test/kotlin/org/mahata/ktlog/UsersControllerTest.kt
+++ b/backend/src/test/kotlin/org/mahata/ktlog/UsersControllerTest.kt
@@ -1,0 +1,43 @@
+package org.mahata.ktlog
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class UsersControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `When the user is not authorized, it returns null values`() {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/users/me"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.name").value(null))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.email").value(null))
+    }
+
+    @Test
+    fun `When the user is authorized, it returns the user info`() {
+        val user = DefaultOAuth2User(
+            emptyList(),
+            mapOf("name" to "Yasunori", "email" to "mahata777@gmail.com"),
+            "name"
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/users/me")
+                .with(SecurityMockMvcRequestPostProcessors.oauth2Login().oauth2User(user))
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Yasunori"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.email").value("mahata777@gmail.com"))
+    }
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a new endpoint `/api/v1/users/me` to retrieve authenticated user information, including name and email.
- Enhancement: Modified the `UserResponse` data class to allow nullable values for `name` and `email`.
- Enhancement: Modified the `me` function in the `UsersController` to handle nullability properly when retrieving the user's name and email from the `attributes` map.
- Test: Added test cases for the `/api/v1/users/me` endpoint to verify that it returns null values for unauthenticated users and the correct user information for authenticated users.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->