### PR TITLE
👷 Add checks for Dependabot's PRs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Run Spring Boot tests
         run: cd backend && ./gradlew test

--- a/.github/workflows/dependabot-check.yml
+++ b/.github/workflows/dependabot-check.yml
@@ -1,0 +1,57 @@
+name: Dependabot Check
+
+on:
+  push:
+    branches:
+      - dependabot/**
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.OS }}-node-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+
+      - name: Test Frontend with Vitest
+        run: |
+          cd frontend
+          npm install
+          npx vitest run
+
+      - name: Build Frontend so that Backend can host it
+        run: |
+          cd frontend
+          npx vite build --outDir ./dist
+
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.OS }}-gradle-${{ hashFiles('backend/**.gradle*', 'backend/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.OS }}-gradle-
+
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Run Spring Boot tests
+        run: cd backend && ./gradlew test


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Release Notes:

- New Feature: Updated Java version from 17 to 21 for running Spring Boot tests.
- New Feature: Added a GitHub Actions workflow file that sets up two jobs: "frontend" and "backend". The "frontend" job tests and builds the frontend using Vitest, while the "backend" job runs Spring Boot tests.
- Chore: Workflow is triggered on push events to branches starting with "dependabot/".
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->