### PR TITLE
♻️ Add jotai for the state management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,9 +5,11 @@ import Header from "./Header";
 import EyeCatch from "./EyeCatch";
 import { Route, Routes } from "react-router-dom";
 import Article from "./Article";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { UsersRepository } from "./repository/UsersRepository";
 import Modal from "./Modal";
+import { useAtom } from "jotai";
+import { modalAtom } from "./Modal.atoms";
 
 type Props = {
   ktlogDomain: string;
@@ -20,7 +22,7 @@ export default function App({
   articlesRepository,
   usersRepository,
 }: Props) {
-  const [showModal] = useState(false);
+  const [showModal] = useAtom(modalAtom);
 
   useEffect(() => {
     if (["localhost", "127.0.0.1"].includes(ktlogDomain)) {

--- a/frontend/src/Modal.atoms.ts
+++ b/frontend/src/Modal.atoms.ts
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const modalAtom = atom(false);

--- a/frontend/src/Modal.tsx
+++ b/frontend/src/Modal.tsx
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
+import { useAtom } from "jotai";
+import { modalAtom } from "./Modal.atoms";
 
 export default function Modal() {
+  const [, setShowModal] = useAtom(modalAtom);
+
   useEffect(() => {
     document.body.style.overflowY = "hidden";
 
@@ -9,5 +13,10 @@ export default function Modal() {
     };
   }, []);
 
-  return <div>This is going to be a modal window</div>;
+  return (
+    <>
+      <h1>This is going to be a modal window</h1>
+      <button onClick={() => setShowModal(false)}>Click me to close</button>
+    </>
+  );
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import "reset-css";
 import { BrowserRouter } from "react-router-dom";
 import { NetworkArticlesRepository } from "./repository/ArticlesRepository";
 import { NetworkUsersRepository } from "./repository/UsersRepository";
+import { Provider } from "jotai";
 
 const networkArticlesRepo = new NetworkArticlesRepository();
 const networkUsersRepo = new NetworkUsersRepository();
@@ -12,11 +13,13 @@ const networkUsersRepo = new NetworkUsersRepository();
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App
-        ktlogDomain={window.location.hostname}
-        articlesRepository={networkArticlesRepo}
-        usersRepository={networkUsersRepo}
-      />
+      <Provider>
+        <App
+          ktlogDomain={window.location.hostname}
+          articlesRepository={networkArticlesRepo}
+          usersRepository={networkUsersRepo}
+        />
+      </Provider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "ktlog",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "jotai": "^2.6.0"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.6.0.tgz",
+      "integrity": "sha512-Vt6hsc04Km4j03l+Ax+Sc+FVft5cRJhqgxt6GTz6GM2eM3DyX3CdBdzcG0z2FrlZToL1/0OAkqDghIyARWnSuQ==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "jotai": "^2.6.0"
+  }
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Release Notes:

- New Feature: Introduced Jotai for state management in the codebase.
- Bug Fix: Replaced `useState` with `useAtom` from Jotai in `App.tsx` and `Modal.atoms.ts`.
- New Feature: Added `modalAtom` atom initialized with the value `false` in `App.tsx` and `Modal.atoms.ts`.
- Refactor: Replaced local state variable `showModal` with `modalAtom` atom in `App.tsx`.
- New Feature: Added Jotai state management to the `Modal` component in `Modal.tsx`.
- Refactor: Modified the return statement of the `Modal` component to include a heading and a button.
- New Feature: Added close button to the modal window in `Modal.tsx`.
- New Feature: Added Jotai state management to the `Main` component in `main.tsx`.
- Documentation: Updated changesets to provide a clearer overview of the changes.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->