### PR TITLE
✨ Introduce the toggle feature of the modal view

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,7 +1,8 @@
 import App from "./App";
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { StubArticlesRepository, StubUsersRepository } from "./StubRepos";
 import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
 
 const originalTitle = document.title;
 
@@ -46,6 +47,28 @@ describe("App", () => {
     });
 
     expect(document.title).toBe(originalTitle);
+  });
+
+  it("shows a modal when the 'login' button is clicked", async () => {
+    await act(async () => {
+      render(
+        <App
+          ktlogDomain="example.com"
+          articlesRepository={stubArticleRepository}
+          usersRepository={stubUsersRepository}
+        />,
+        {
+          wrapper: MemoryRouter,
+        },
+      );
+    });
+
+    const loginButton = screen.getByRole("button", {
+      name: "Login",
+    }) as HTMLButtonElement;
+
+    await userEvent.click(loginButton);
+    expect(await screen.findByText("login modal")).toBeInTheDocument();
   });
 
   afterEach(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,7 +44,7 @@ export default function App({
           element={<Article articlesRepository={articlesRepository} />}
         />
       </Routes>
-      {showModal && <Modal />}
+      {showModal && <Modal title="login modal" />}
     </div>
   );
 }

--- a/frontend/src/Header.test.tsx
+++ b/frontend/src/Header.test.tsx
@@ -15,7 +15,7 @@ describe("Header", () => {
   });
 
   describe("Login", () => {
-    it("shows 'login' link when the user isn't logged in", () => {
+    it("shows 'login' button when the user isn't logged in", () => {
       stubUsersRepository.getMe.mockResolvedValue({
         name: null,
         email: null,
@@ -25,14 +25,11 @@ describe("Header", () => {
         wrapper: MemoryRouter,
       });
 
-      const loginLink = screen.getByRole("link", {
+      const loginButton = screen.getByRole("button", {
         name: "Login",
       }) as HTMLAnchorElement;
 
-      expect(loginLink).toBeInTheDocument();
-      expect(loginLink.href).toBe(
-        window.location.origin + "/oauth2/authorization/github",
-      );
+      expect(loginButton).toBeInTheDocument();
     });
 
     it("shows a username when the user is logged in", async () => {

--- a/frontend/src/Header.tsx
+++ b/frontend/src/Header.tsx
@@ -2,12 +2,15 @@ import { Link } from "react-router-dom";
 import styles from "./Header.module.scss";
 import { useEffect, useState } from "react";
 import { UsersRepository } from "./repository/UsersRepository";
+import { useAtom } from "jotai";
+import { modalAtom } from "./Modal.atoms";
 
 type Props = {
   usersRepository: UsersRepository;
 };
 
 export default function Header({ usersRepository }: Props) {
+  const [, setShowModal] = useAtom(modalAtom);
   const [username, setUsername] = useState<string>("");
 
   useEffect(() => {
@@ -32,7 +35,7 @@ export default function Header({ usersRepository }: Props) {
           {username ? (
             username
           ) : (
-            <a href="/oauth2/authorization/github">Login</a>
+            <button onClick={() => setShowModal(true)}>Login</button>
           )}
         </div>
       </nav>

--- a/frontend/src/Modal.test.tsx
+++ b/frontend/src/Modal.test.tsx
@@ -5,13 +5,13 @@ describe("Modal", () => {
   it("restricts page scrolling when it's active", () => {
     expect(window.document.body.style.overflowY).not.toBe("hidden");
 
-    render(<Modal />);
+    render(<Modal title="DOES NOT MATTER" />);
 
     expect(window.document.body.style.overflowY).toBe("hidden");
   });
 
   it("allows page scrolling when it's inactive", () => {
-    const { unmount } = render(<Modal />);
+    const { unmount } = render(<Modal title="DOES NOT MATTER" />);
 
     unmount();
 

--- a/frontend/src/Modal.tsx
+++ b/frontend/src/Modal.tsx
@@ -2,7 +2,11 @@ import { useEffect } from "react";
 import { useAtom } from "jotai";
 import { modalAtom } from "./Modal.atoms";
 
-export default function Modal() {
+type Props = {
+  title: string;
+};
+
+export default function Modal({ title }: Props) {
   const [, setShowModal] = useAtom(modalAtom);
 
   useEffect(() => {
@@ -15,7 +19,7 @@ export default function Modal() {
 
   return (
     <>
-      <h1>This is going to be a modal window</h1>
+      <h1>{title}</h1>
       <button onClick={() => setShowModal(false)}>Click me to close</button>
     </>
   );


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a toggle feature for the modal view in the App component, allowing the modal to display a title when `showModal` is true.
- New Feature: Replaced the login link with a login button in the Header component, triggering a modal view controlled by the `modalAtom` state from the `jotai` library.
- Test: Added a new test case to check if a modal is displayed when the "login" button is clicked in the App component.
- Test: Updated the test case for the login functionality in the Header component to use a login button instead of a login link and check for the presence of the login button in the DOM.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->